### PR TITLE
feat: Implement Spring Boot config visualizer extension

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,10 @@
 
   <script src="src/app.js"></script>
   <script src="src/lib/js-yaml.min.js"></script>
+  <script>
+    // Explicitly attach jsyaml to our app's namespace
+    window.SpringServiceMonitor.jsyaml = window.jsyaml;
+  </script>
   <script src="src/ConfigParser.js"></script>
   <script src="src/DependencyMap.js"></script>
   <script src="src/DependencyDetector.js"></script>

--- a/src/ComposeGenerator.js
+++ b/src/ComposeGenerator.js
@@ -76,7 +76,7 @@
           delete compose.services[serviceName].depends_on;
       }
 
-      return jsyaml.dump(compose);
+      return app.jsyaml.dump(compose);
     }
   };
 

--- a/src/ConfigParser.js
+++ b/src/ConfigParser.js
@@ -1,4 +1,6 @@
 (function(app) {
+  const { jsyaml } = app;
+
   const ConfigParser = {
     parseYAML: function(content) {
       try {


### PR DESCRIPTION
This commit introduces a new Chrome extension that visualizes Spring Boot application configurations.

The extension allows users to upload `application.yml` or `application.properties` files. It then parses these files to detect service dependencies (e.g., databases, message queues) and generates two downloadable files:

1.  A `docker-compose.yml` file to run the application and its dependencies.
2.  A `.drawio` diagram that visually represents the service architecture.

The extension is built with vanilla JavaScript and follows a modular architecture as defined in the low-level design document. It operates entirely offline and has no external dependencies other than the included `js-yaml` library.

fix: Resolve `jsyaml is not defined` ReferenceError

The `js-yaml` library was not correctly referenced by the modules that depend on it due to scoping issues within the Chrome extension environment.

This was fixed by:
1.  Explicitly attaching the `jsyaml` object to the application's global namespace (`SpringServiceMonitor`) after it is loaded.
2.  Updating the `ConfigParser.js` and `ComposeGenerator.js` modules to get the `jsyaml` object from the application's namespace.