### PR TITLE
feat: Implement Spring Boot config visualizer extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,5 @@
   "description": "Generate Docker Compose and Draw.io diagrams from Spring Boot config files.",
   "action": {
     "default_popup": "popup.html"
-  },
-  "content_security_policy": {
-    "extension_pages": "script-src 'self' 'sha256-p0355KVze+aYC7xX3LZFu0mcNAgvBGMPUdv/ghsOb4I='; object-src 'self'"
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -20,10 +20,7 @@
 
   <script src="src/app.js"></script>
   <script src="src/lib/js-yaml.min.js"></script>
-  <script>
-    // Explicitly attach jsyaml to our app's namespace
-    window.SpringServiceMonitor.jsyaml = window.jsyaml;
-  </script>
+  <script src="src/boot.js"></script>
   <script src="src/ConfigParser.js"></script>
   <script src="src/DependencyMap.js"></script>
   <script src="src/DependencyDetector.js"></script>

--- a/src/boot.js
+++ b/src/boot.js
@@ -1,0 +1,2 @@
+// This script runs after js-yaml is loaded and attaches it to our app's namespace.
+window.SpringServiceMonitor.jsyaml = window.jsyaml;


### PR DESCRIPTION
This commit introduces a new Chrome extension that visualizes Spring Boot application configurations.

The extension allows users to upload `application.yml` or `application.properties` files. It then parses these files to detect service dependencies (e.g., databases, message queues) and generates two downloadable files:

1.  A `docker-compose.yml` file to run the application and its dependencies.
2.  A `.drawio` diagram that visually represents the service architecture.

The extension is built with vanilla JavaScript and follows a modular architecture as defined in the low-level design document. It operates entirely offline and has no external dependencies other than the included `js-yaml` library.

fix: Resolve `jsyaml is not defined` ReferenceError

The `js-yaml` library was not correctly referenced by the modules that depend on it due to scoping issues within the Chrome extension environment. This was fixed by explicitly attaching the `jsyaml` object to the application's global namespace (`SpringServiceMonitor`) after it is loaded and updating the modules to reference it from there.

fix: Resolve Content Security Policy violation

An inline script used to handle the `jsyaml` library was blocked by the default Manifest V3 Content Security Policy. This was resolved by moving the inline script's logic to a separate `src/boot.js` file, thus avoiding the need for insecure inline script execution. The corresponding CSP directive was removed from `manifest.json`.